### PR TITLE
fix compiler warning under Xcode 6.3 by using std::abs

### DIFF
--- a/Source/LookAndFeel/MLDial.cpp
+++ b/Source/LookAndFeel/MLDial.cpp
@@ -263,7 +263,7 @@ void MLDial::setRange (const float newMin,
 		setPropertyImmediate("max_value", constrainValue(getFloatProperty("max_value")));
 	}
 	
-	mDigits = ceil(log10(jmax((abs(newMin) + 1.), (abs(newMax) + 1.))));
+    mDigits = ceil(log10(jmax((std::abs(newMin) + 1.), (std::abs(newMax) + 1.))));
 	mDoSign = ((newMax < 0) || (newMin < 0));
 	mPrecision = ceil(log10(1. / newInt) - 0.0001);	
 	

--- a/Source/LookAndFeel/MLLookAndFeel.cpp
+++ b/Source/LookAndFeel/MLLookAndFeel.cpp
@@ -212,7 +212,7 @@ static int maxDigits(const int digits, const int precision)
 int MLLookAndFeel::getDigitsAfterDecimal (const float number, const int digits, const int precision)  throw()
 {
 	int m = maxDigits(digits, precision);
-	int d = ceil(log10(abs(number)+1.));
+	int d = ceil(log10(std::abs(number)+1.));
 	int p;
 	if (d + precision > m)
 	{
@@ -375,7 +375,7 @@ float MLLookAndFeel::getNumberWidth (const float number, const int digits, const
 	char c;
 
 	// calc precision
-	int d = ceil(log10(abs(number)+1.));
+	int d = ceil(log10(std::abs(number)+1.));
 	int p;
 	if (d + precision > m)
 	{
@@ -1760,8 +1760,8 @@ static void spikyPathTo(Path& p, const float x2, const float y2, const int doSpi
 		float baseX, baseY;		
 		
 		// set half width of spike base
-		baseX = min((double)abs(y3 - sy), abs(x2 - x1) / 2.);
-		baseY = min((double)abs(x3 - sx), abs(y2 - y1) / 2.);
+		baseX = min((double)std::abs(y3 - sy), std::abs(x2 - x1) / 2.);
+		baseY = min((double)std::abs(x3 - sx), std::abs(y2 - y1) / 2.);
 		if (x2 > x1) baseX *= -1;
 		if (y2 > y1) baseY *= -1;
 		baseX = floor(baseX);


### PR DESCRIPTION
small compiler warning fix for Xcode 6 (its backwards compatible for older Xcode ), basically moves to using <cmath> rather than <maths.h> 