### PR TITLE
Fixed build error in VS2019 caused by FLT_MAX being redefined

### DIFF
--- a/source/DSP/MLDSPScalarMath.h
+++ b/source/DSP/MLDSPScalarMath.h
@@ -14,7 +14,6 @@
 #ifdef WIN32
 #undef min
 #undef max
-  constexpr float FLT_MAX = 3.40282346638528860e+38f;
 #endif
 
 namespace ml


### PR DESCRIPTION
Is this line required by older versions of visual studio perhaps? In VS2019 it's a compile error.