### PR TITLE
ml::lerp helper overload

### DIFF
--- a/source/DSP/MLDSPScalarMath.h
+++ b/source/DSP/MLDSPScalarMath.h
@@ -71,7 +71,13 @@ namespace ml
 	{
 		return(a + m*(b-a));
 	}
-	
+
+	template <class c, class d>
+	inline c lerp(const c& a, const c& b, const d& m)
+	{
+		return(a + c(m) * (b - a));
+	}
+
 	// return bool value of within half-open interval [min, max).
 	template <class c>
 	inline bool (within)(const c& x, const c& min, const c& max)


### PR DESCRIPTION
The motivation for this is to allow the following code to compile:

```c++
ml::DSPVectorArray<2> dry;
ml::DSPVectorArray<2> wet;

float mix = 0.5f;

return ml::lerp(dry, wet, mix);
```

Currently the last line won't compile as `mix` needs to be explicitly converted to `DSPVectorArray<2>` first,

ie.
```
return ml::lerp(dry, wet, ml::DSPVectorArray<2>(mix));
```