### PR TITLE
Additional DSPVectorArray arithmetic assignment operators

### DIFF
--- a/source/DSP/MLDSPOps.h
+++ b/source/DSP/MLDSPOps.h
@@ -325,6 +325,15 @@ namespace ml
     inline DSPVectorArray& operator*=(const DSPVectorArray& x1){*this = multiply(*this, x1); return *this;}
     inline DSPVectorArray& operator/=(const DSPVectorArray& x1){*this = divide(*this, x1); return *this;}
 
+    template <typename = typename std::enable_if<VECTORS != 1>::type>
+    inline DSPVectorArray& operator+=(const DSPVectorArray<1>& x1) { *this = add(*this, repeat<2, 1>(x1)); return *this; }
+    template <typename = typename std::enable_if<VECTORS != 1>::type>
+    inline DSPVectorArray& operator-=(const DSPVectorArray<1>& x1) { *this = subtract(*this, repeat<2, 1>(x1)); return *this; }
+    template <typename = typename std::enable_if<VECTORS != 1>::type>
+    inline DSPVectorArray& operator*=(const DSPVectorArray<1>& x1) { *this = multiply(*this, repeat<2, 1>(x1)); return *this; }
+    template <typename = typename std::enable_if<VECTORS != 1>::type>
+    inline DSPVectorArray& operator/=(const DSPVectorArray<1>& x1) { *this = divide(*this, repeat<2, 1>(x1)); return *this; }
+
     // declare as friends any templates or functions that need to use get/setRowVectorUnchecked
     // but maybe they should just use row()?
     template<int C, int V>
@@ -578,6 +587,15 @@ namespace ml
   inline DSPVectorArray<VECTORS> operator*(DSPVectorArray<VECTORS> x1, DSPVectorArray<VECTORS> x2){return multiply(x1, x2);}
   template<int VECTORS>
   inline DSPVectorArray<VECTORS> operator/(DSPVectorArray<VECTORS> x1, DSPVectorArray<VECTORS> x2){return divide(x1, x2);}
+
+  template<int VECTORS>
+  inline DSPVectorArray<VECTORS> operator+(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return add(x1, repeat<2, 1>(x2)); }
+  template<int VECTORS>
+  inline DSPVectorArray<VECTORS> operator-(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return subtract(x1, repeat<2, 1>(x2)); }
+  template<int VECTORS>
+  inline DSPVectorArray<VECTORS> operator*(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return multiply(x1, repeat<2, 1>(x2)); }
+  template<int VECTORS>
+  inline DSPVectorArray<VECTORS> operator/(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return divide(x1, repeat<2, 1>(x2)); }
 
   DEFINE_OP2(divideApprox, vecDivApprox(x1, x2) );
   DEFINE_OP2(pow, (vecExp(vecMul(vecLog(x1), x2))));

--- a/source/DSP/MLDSPOps.h
+++ b/source/DSP/MLDSPOps.h
@@ -326,13 +326,13 @@ namespace ml
     inline DSPVectorArray& operator/=(const DSPVectorArray& x1){*this = divide(*this, x1); return *this;}
 
     template <typename = typename std::enable_if<VECTORS != 1>::type>
-    inline DSPVectorArray& operator+=(const DSPVectorArray<1>& x1) { *this = add(*this, repeat<2, 1>(x1)); return *this; }
+    inline DSPVectorArray& operator+=(const DSPVectorArray<1>& x1) { *this = add(*this, repeat<VECTORS, 1>(x1)); return *this; }
     template <typename = typename std::enable_if<VECTORS != 1>::type>
-    inline DSPVectorArray& operator-=(const DSPVectorArray<1>& x1) { *this = subtract(*this, repeat<2, 1>(x1)); return *this; }
+    inline DSPVectorArray& operator-=(const DSPVectorArray<1>& x1) { *this = subtract(*this, repeat<VECTORS, 1>(x1)); return *this; }
     template <typename = typename std::enable_if<VECTORS != 1>::type>
-    inline DSPVectorArray& operator*=(const DSPVectorArray<1>& x1) { *this = multiply(*this, repeat<2, 1>(x1)); return *this; }
+    inline DSPVectorArray& operator*=(const DSPVectorArray<1>& x1) { *this = multiply(*this, repeat<VECTORS, 1>(x1)); return *this; }
     template <typename = typename std::enable_if<VECTORS != 1>::type>
-    inline DSPVectorArray& operator/=(const DSPVectorArray<1>& x1) { *this = divide(*this, repeat<2, 1>(x1)); return *this; }
+    inline DSPVectorArray& operator/=(const DSPVectorArray<1>& x1) { *this = divide(*this, repeat<VECTORS, 1>(x1)); return *this; }
 
     // declare as friends any templates or functions that need to use get/setRowVectorUnchecked
     // but maybe they should just use row()?
@@ -589,13 +589,13 @@ namespace ml
   inline DSPVectorArray<VECTORS> operator/(DSPVectorArray<VECTORS> x1, DSPVectorArray<VECTORS> x2){return divide(x1, x2);}
 
   template<int VECTORS>
-  inline DSPVectorArray<VECTORS> operator+(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return add(x1, repeat<2, 1>(x2)); }
+  inline DSPVectorArray<VECTORS> operator+(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return add(x1, repeat<VECTORS, 1>(x2)); }
   template<int VECTORS>
-  inline DSPVectorArray<VECTORS> operator-(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return subtract(x1, repeat<2, 1>(x2)); }
+  inline DSPVectorArray<VECTORS> operator-(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return subtract(x1, repeat<VECTORS, 1>(x2)); }
   template<int VECTORS>
-  inline DSPVectorArray<VECTORS> operator*(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return multiply(x1, repeat<2, 1>(x2)); }
+  inline DSPVectorArray<VECTORS> operator*(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return multiply(x1, repeat<VECTORS, 1>(x2)); }
   template<int VECTORS>
-  inline DSPVectorArray<VECTORS> operator/(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return divide(x1, repeat<2, 1>(x2)); }
+  inline DSPVectorArray<VECTORS> operator/(DSPVectorArray<VECTORS> x1, DSPVectorArray<1> x2) { return divide(x1, repeat<VECTORS, 1>(x2)); }
 
   DEFINE_OP2(divideApprox, vecDivApprox(x1, x2) );
   DEFINE_OP2(pow, (vecExp(vecMul(vecLog(x1), x2))));


### PR DESCRIPTION
These additions enable operations where VECTORS>1 on the left hand side and VECTORS==1 on the right hand side,
for example

```c++
ml::DSPVectorArray<2> stereo_signal;
ml::DSPVectorArray<1> volume;

...

stereo_signal *= volume;
```
Maybe there is a good reason you don't already enable this,. Is there a potential pitfall i'm missing from having this happen implicitly?

The overloads are implemented by calling repeat<VECTORS, 1>() on the right hand argument.

The enable_if miasma is necessary to prevent the method redefinitions in the case of VECTORS also being 1 on the left hand side.