### PR TITLE
Add LinearGlide::setValue()

### DIFF
--- a/source/DSP/MLDSPGens.h
+++ b/source/DSP/MLDSPGens.h
@@ -257,48 +257,48 @@ namespace ml
 	
 	class LinearGlide
 	{
-    DSPVector mCurrVec;
-    DSPVector mStepVec;
-    float mTargetValue;
-    float mDyPerVector;
-    int mVectorsPerGlide;
-    int mVectorsRemaining;
+		DSPVector mCurrVec;
+		DSPVector mStepVec;
+		float mTargetValue;
+		float mDyPerVector;
+		int mVectorsPerGlide;
+		int mVectorsRemaining;
 
 	public:
-    LinearGlide() :
-    mCurrVec(0.f),
-    mStepVec(0.f),
-    mTargetValue(0.f),
-    mVectorsPerGlide(32),
-    mVectorsRemaining(0)
-    {}
+		LinearGlide() :
+			mCurrVec(0.f),
+			mStepVec(0.f),
+			mTargetValue(0.f),
+			mVectorsPerGlide(32),
+			mVectorsRemaining(0)
+		{}
 		
 		void setGlideTimeInSamples(float t)
 		{
-      mVectorsPerGlide = t/kFloatsPerDSPVector;
-      if(mVectorsPerGlide < 1) mVectorsPerGlide = 1;
-      mDyPerVector = 1.0f/(mVectorsPerGlide + 0.f);
+			mVectorsPerGlide = t/kFloatsPerDSPVector;
+			if(mVectorsPerGlide < 1) mVectorsPerGlide = 1;
+			mDyPerVector = 1.0f/(mVectorsPerGlide + 0.f);
 		}
 
 		DSPVector operator()(float f)
 		{
-      // set target value if different from current value.
-      //const float currentValue = mCurrVec[kFloatsPerDSPVector - 1];
-      if(f != mTargetValue)
-      {
-        mTargetValue = f;
+			// set target value if different from current value.
+			//const float currentValue = mCurrVec[kFloatsPerDSPVector - 1];
+			if(f != mTargetValue)
+			{
+				mTargetValue = f;
 
-        // start counter
-        mVectorsRemaining = mVectorsPerGlide;
-      }
+				// start counter
+				mVectorsRemaining = mVectorsPerGlide;
+			}
 
-      // process glide
+			// process glide
 			if(mVectorsRemaining == 0)
 			{
-        // end glide: write target value to output vector
+				// end glide: write target value to output vector
 				mCurrVec = DSPVector(mTargetValue);
-        mStepVec = DSPVector(0.f);
-        mVectorsRemaining--;
+				mStepVec = DSPVector(0.f);
+				mVectorsRemaining--;
 			}
 			else if(mVectorsRemaining == mVectorsPerGlide)
 			{

--- a/source/DSP/MLDSPGens.h
+++ b/source/DSP/MLDSPGens.h
@@ -280,6 +280,13 @@ namespace ml
 			mDyPerVector = 1.0f/(mVectorsPerGlide + 0.f);
 		}
 
+		// set the current value to the given value immediately, without gliding
+		void setValue(float f)
+		{
+			mTargetValue = f;
+			mVectorsRemaining = 0;
+		}
+
 		DSPVector operator()(float f)
 		{
 			// set target value if different from current value.


### PR DESCRIPTION
I added this to fix some initialization issues I was having. For example if the smoothed frequency of a filter starts at 1000hz, without a way to directly set the starting value the frequency will always ramp up from zero to 1000 when the filter begins processing.

I also fixed the whitespace of this class to match the rest of the file as it is currently a mixture of tabs and spaces (this is in a separate commit).