### PR TITLE
Add add, subtract and select operations for integers (better pull request)

### DIFF
--- a/source/DSP/MLDSPMathSSE.h
+++ b/source/DSP/MLDSPMathSSE.h
@@ -121,6 +121,7 @@ inline bool isSIMDAligned(float* p)
 #define vecIntToFloat _mm_cvtepi32_ps
 
 #define vecAddInt _mm_add_epi32
+#define vecSubInt _mm_sub_epi32
 #define vecSet1Int _mm_set1_epi32
 
 typedef union
@@ -208,6 +209,13 @@ inline SIMDVectorFloat vecSelect(SIMDVectorFloat a, SIMDVectorFloat b, SIMDVecto
   __m128i ones = _mm_set1_epi32(-1);
   return _mm_or_ps(_mm_and_ps(VecI2F(conditionMask), a),
                    _mm_and_ps(_mm_xor_ps(VecI2F(conditionMask), VecI2F(ones)), b));
+}
+
+inline SIMDVectorInt vecSelect(SIMDVectorInt a, SIMDVectorInt b, SIMDVectorInt conditionMask)
+{
+  __m128i ones = _mm_set1_epi32(-1);
+  return _mm_or_si128(_mm_and_si128(conditionMask, a),
+                      _mm_and_si128(_mm_xor_si128(conditionMask, ones), b));
 }
 
 // ----------------------------------------------------------------

--- a/source/DSP/MLDSPOps.h
+++ b/source/DSP/MLDSPOps.h
@@ -466,6 +466,16 @@ class DSPVectorArrayInt
     return *pRow;
   }
 
+  friend inline DSPVectorArrayInt operator+(const DSPVectorArrayInt& x1, const DSPVectorArrayInt& x2)
+  {
+    return addInt32(x1, x2);
+  }
+
+  friend inline DSPVectorArrayInt operator-(const DSPVectorArrayInt& x1, const DSPVectorArrayInt& x2)
+  {
+    return subtractInt32(x1, x2);
+  }
+
 };  // class DSPVectorArrayInt
 
 typedef DSPVectorArrayInt<1> DSPVectorInt;
@@ -568,7 +578,7 @@ DEFINE_OP1(log2Approx, (vecMul(vecLogApprox(x), kLogTwoRVec)));
 DEFINE_OP1(exp2Approx, (vecExpApprox(vecMul(kLogTwoVec, x))));
 
 // ----------------------------------------------------------------
-// binary vector operators
+// binary vector operators (float)
 
 #define DEFINE_OP2(opName, opComputation)                              \
   template <size_t ROWS>                                               \
@@ -601,6 +611,33 @@ DEFINE_OP2(pow, (vecExp(vecMul(vecLog(x1), x2))));
 DEFINE_OP2(powApprox, (vecExpApprox(vecMul(vecLogApprox(x1), x2))));
 DEFINE_OP2(min, (vecMin(x1, x2)));
 DEFINE_OP2(max, (vecMax(x1, x2)));
+
+// ----------------------------------------------------------------
+// binary vector operators (int32)
+
+#define DEFINE_OP2_INT32(opName, opComputation)                              \
+  template <size_t ROWS>                                                     \
+  inline DSPVectorArrayInt<ROWS>(opName)(const DSPVectorArrayInt<ROWS>& vx1, \
+                                         const DSPVectorArrayInt<ROWS>& vx2) \
+  {                                                                          \
+    DSPVectorArrayInt<ROWS> vy;                                              \
+    const float* px1 = vx1.getConstBuffer();                                 \
+    const float* px2 = vx2.getConstBuffer();                                 \
+    float* py1 = vy.getBuffer();                                             \
+    for (int n = 0; n < kSIMDVectorsPerDSPVector * ROWS; ++n)                \
+    {                                                                        \
+      SIMDVectorInt x1 = VecF2I(vecLoad(px1));                               \
+      SIMDVectorInt x2 = VecF2I(vecLoad(px2));                               \
+      vecStore(py1, VecI2F(opComputation));                                  \
+      px1 += kIntsPerSIMDVector;                                             \
+      px2 += kIntsPerSIMDVector;                                             \
+      py1 += kIntsPerSIMDVector;                                             \
+    }                                                                        \
+    return vy;                                                               \
+  }
+
+DEFINE_OP2_INT32(subtractInt32, (vecSubInt(x1, x2)));
+DEFINE_OP2_INT32(addInt32, (vecAddInt(x1, x2)));
 
 // ----------------------------------------------------------------
 // ternary vector operators
@@ -772,6 +809,42 @@ DEFINE_OP2_FF2I(lessThanOrEqual, (vecLessThanOrEqual(x1, x2)));
 DEFINE_OP3_FFI2F(select, vecSelect(x1, x2, x3));  // bitwise select(resultIfTrue,
                                                   // resultIfFalse, conditionMask)
 
+template <size_t ROWS, typename... Args>
+DSPVectorArray<ROWS> add(DSPVectorArray<ROWS> first, Args... args)
+{
+  // the outer add here is the operator defined using vecAdd() above
+  return first + add(args...);
+}
+// ternary operators int vector, int vector, int vector -> int vector
+
+#define DEFINE_OP3_III2I(opName, opComputation)                             \
+  template <size_t ROWS>                                                    \
+  inline DSPVectorArrayInt<ROWS>(opName)(const DSPVectorArrayInt<ROWS>& vx1,\
+                                      const DSPVectorArrayInt<ROWS>& vx2,   \
+                                      const DSPVectorArrayInt<ROWS>& vx3)   \
+  {                                                                         \
+    DSPVectorArrayInt<ROWS> vy;                                             \
+    const float* px1 = vx1.getConstBuffer();                                \
+    const float* px2 = vx2.getConstBuffer();                                \
+    const float* px3 = vx3.getConstBuffer();                                \
+    float* py1 = vy.getBuffer();                                            \
+    for (int n = 0; n < kSIMDVectorsPerDSPVector * ROWS; ++n)               \
+    {                                                                       \
+      SIMDVectorInt x1 = VecF2I(vecLoad(px1));                              \
+      SIMDVectorInt x2 = VecF2I(vecLoad(px2));                              \
+      SIMDVectorInt x3 = VecF2I(vecLoad(px3));                              \
+      vecStore(py1, VecI2F(opComputation));                                 \
+      px1 += kIntsPerSIMDVector;                                            \
+      px2 += kIntsPerSIMDVector;                                            \
+      px3 += kIntsPerSIMDVector;                                            \
+      py1 += kIntsPerSIMDVector;                                            \
+    }                                                                       \
+    return vy;                                                              \
+  }
+
+DEFINE_OP3_III2I(select, vecSelect(x1, x2, x3));  // bitwise select(resultIfTrue,
+                                                  // resultIfFalse, conditionMask)
+
 // ----------------------------------------------------------------
 // n-ary operators
 
@@ -781,13 +854,6 @@ template <size_t ROWS>
 DSPVectorArray<ROWS> add(DSPVectorArray<ROWS> a)
 {
   return a;
-}
-
-template <size_t ROWS, typename... Args>
-DSPVectorArray<ROWS> add(DSPVectorArray<ROWS> first, Args... args)
-{
-  // the outer add here is the operator defined using vecAdd() above
-  return first + add(args...);
 }
 
 // ----------------------------------------------------------------


### PR DESCRIPTION
I am doing more complex things with vectorized ints so I need some of these operations implemented.

Obviously the changes are a bit of a mess as I am following the existing copy+paste convention. I think you said previously that you plan to rewrite DSPVectorArrayInt in a cleaner way that reduces all the code duplication, so perhaps you would prefer for me to keep this stuff in my own fork. But I thought I should open the pull request at least as a discussion item and to register the fact that somebody does need this stuff.

These three ops are all I need right now. If I do end up needing to add more then maybe I should have a go at a refactor myself to resolve the float/int duplication but it would probably be a big change and I don't want to start stepping on your toes.