### PR TITLE
Add ml::rotateLeft and ml::rotateRight

### DIFF
--- a/source/DSP/MLDSPMathSSE.h
+++ b/source/DSP/MLDSPMathSSE.h
@@ -856,3 +856,17 @@ inline SIMDVectorFloat vecFracPart(SIMDVectorFloat val)
   SIMDVectorFloat intPart = _mm_cvtepi32_ps(vi);
   return _mm_sub_ps(val, intPart);
 }
+
+// Given vectors [ ?, ?, ?, 3 ], [ 4, 5, 6, 7 ]
+// Returns [ 3, 4, 5, 6 ]
+inline SIMDVectorFloat vecShuffleRight(SIMDVectorFloat v1, SIMDVectorFloat v2)
+{
+  return _mm_shuffle_ps(_mm_shuffle_ps(v2, v1, SHUFFLE(3, 3, 0, 0)), v2, SHUFFLE(2, 1, 0, 3));
+}
+
+// Given vectors [ 0, 1, 2, 3 ], [ 4, ?, ?, ? ]
+// Returns [ 1, 2, 3, 4 ]
+inline SIMDVectorFloat vecShuffleLeft(SIMDVectorFloat v1, SIMDVectorFloat v2)
+{
+  return _mm_shuffle_ps(v1, _mm_shuffle_ps(v1, v2, SHUFFLE(0, 0, 3, 3)), SHUFFLE(3, 0, 2, 1));
+}

--- a/source/DSP/MLDSPOps.h
+++ b/source/DSP/MLDSPOps.h
@@ -1181,23 +1181,26 @@ inline ml::DSPVectorArray<ROWS> rotateRight(const ml::DSPVectorArray<ROWS>& x)
 {
   ml::DSPVectorArray<ROWS> vy;
 
-  const float* px1 = x.getConstBuffer() + (row * kFloatsPerDSPVector);
-  const float* px2 = px1 + kFloatsPerSIMDVector;
-  float* py1 = vy.getBuffer() + (row * kFloatsPerDSPVector) + kFloatsPerSIMDVector;
-
-  for (int n = 0; n < kSIMDVectorsPerDSPVector - 1; ++n)
+  for (size_t row = 0; row < ROWS; row++)
   {
+    const float* px1 = x.getConstBuffer() + (row * kFloatsPerDSPVector);
+    const float* px2 = px1 + kFloatsPerSIMDVector;
+    float* py1 = vy.getBuffer() + (row * kFloatsPerDSPVector) + kFloatsPerSIMDVector;
+
+    for (int n = 0; n < kSIMDVectorsPerDSPVector - 1; ++n)
+    {
+      vecStore(py1, vecShuffleRight(vecLoad(px1), vecLoad(px2)));
+
+      px1 += kFloatsPerSIMDVector;
+      px2 += kFloatsPerSIMDVector;
+      py1 += kFloatsPerSIMDVector;
+    }
+
+    px2 = x.getConstBuffer() + (row * kFloatsPerDSPVector);
+    py1 = vy.getBuffer() + (row * kFloatsPerDSPVector);
+
     vecStore(py1, vecShuffleRight(vecLoad(px1), vecLoad(px2)));
-
-    px1 += kFloatsPerSIMDVector;
-    px2 += kFloatsPerSIMDVector;
-    py1 += kFloatsPerSIMDVector;
   }
-
-  px2 = x.getConstBuffer() + (row * kFloatsPerDSPVector);
-  py1 = vy.getBuffer() + (row * kFloatsPerDSPVector);
-
-  vecStore(py1, vecShuffleRight(vecLoad(px1), vecLoad(px2)));
 
   return vy;
 }

--- a/source/DSP/MLDSPOps.h
+++ b/source/DSP/MLDSPOps.h
@@ -1144,6 +1144,64 @@ inline DSPVectorArray<ROWSA + ROWSB + ROWSC + ROWSD> concatRows(const DSPVectorA
   return vy;
 }
 
+// Rotate the elements of each row of a DSPVectorArray by one element left.
+// The first element of each row is moved to the end
+template <size_t ROWS>
+inline ml::DSPVectorArray<ROWS> rotateLeft(const ml::DSPVectorArray<ROWS>& x)
+{
+  ml::DSPVectorArray<ROWS> vy;
+
+  for (size_t row = 0; row < ROWS; row++)
+  {
+    const float* px1 = x.getConstBuffer() + (row * kFloatsPerDSPVector);
+    const float* px2 = px1 + kFloatsPerSIMDVector;
+    float* py1 = vy.getBuffer() + (row * kFloatsPerDSPVector);
+
+    for (int n = 0; n < kSIMDVectorsPerDSPVector - 1; ++n)
+    {
+      vecStore(py1, vecShuffleLeft(vecLoad(px1), vecLoad(px2)));
+
+      px1 += kFloatsPerSIMDVector;
+      px2 += kFloatsPerSIMDVector;
+      py1 += kFloatsPerSIMDVector;
+    }
+
+    px2 = x.getConstBuffer() + (row * kFloatsPerDSPVector);
+
+    vecStore(py1, vecShuffleLeft(vecLoad(px1), vecLoad(px2)));
+  }
+
+  return vy;
+}
+
+// Rotate the elements of each row of a DSPVectorArray by one element right.
+// The last element of each row is moved to the start
+template <size_t ROWS>
+inline ml::DSPVectorArray<ROWS> rotateRight(const ml::DSPVectorArray<ROWS>& x)
+{
+  ml::DSPVectorArray<ROWS> vy;
+
+  const float* px1 = x.getConstBuffer() + (row * kFloatsPerDSPVector);
+  const float* px2 = px1 + kFloatsPerSIMDVector;
+  float* py1 = vy.getBuffer() + (row * kFloatsPerDSPVector) + kFloatsPerSIMDVector;
+
+  for (int n = 0; n < kSIMDVectorsPerDSPVector - 1; ++n)
+  {
+    vecStore(py1, vecShuffleRight(vecLoad(px1), vecLoad(px2)));
+
+    px1 += kFloatsPerSIMDVector;
+    px2 += kFloatsPerSIMDVector;
+    py1 += kFloatsPerSIMDVector;
+  }
+
+  px2 = x.getConstBuffer() + (row * kFloatsPerDSPVector);
+  py1 = vy.getBuffer() + (row * kFloatsPerDSPVector);
+
+  vecStore(py1, vecShuffleRight(vecLoad(px1), vecLoad(px2)));
+
+  return vy;
+}
+
 // shuffle two DSPVectorArrays, alternating x1 to even rows of result and x2 to
 // odd rows. if the sources are different sizes, the excess rows are all
 // appended to the destination after shuffling is done.


### PR DESCRIPTION
I wrote functions to rotate all the elements of a vector one-to-the-left or one-to-the-right. The first or last element is wrapped around to the other end. This happens on a per-row basis so elements don't overflow into adjacent rows. 

This works by traversing the elements two `SIMDVectorFloat`s at a time and performing a pair of `_mm_shuffle_ps`'s to shuffle the elements into the right places. I'm not experienced in writing SSE stuff so I don't know if there is a better way of doing this.

I think it is fair if you feel this is too esoteric an operation to include in madronalib but I thought I should share it anyway in case you were interested. I am working on a vocal tract model and experimenting with representing the tract using DSPVectors instead of plain arrays and these operations are useful when calculating reflections.