### PR TITLE
fix MLTimer compilation on Linux

### DIFF
--- a/source/app/MLTimer.cpp
+++ b/source/app/MLTimer.cpp
@@ -157,7 +157,7 @@ void ml::Timers::run(void)
 
 #elif ML_LINUX
 
-void Timers::start(bool runInMainThread)
+void ml::Timers::start(bool runInMainThread)
 {
   if (!_running)
   {


### PR DESCRIPTION
Add missing namespace to `Timers::start` implementation for Linux

