### PR TITLE
Additional linux and gcc6/8 compatibility for MLTimer

### DIFF
--- a/source/app/MLTimer.cpp
+++ b/source/app/MLTimer.cpp
@@ -169,6 +169,15 @@ void ml::Timers::run(void)
   }
 }
 
+void ml::Timers::stop(void)
+{
+  if (_running)
+  {
+    _running = false;
+    runThread.join();
+  }
+}
+
 #endif
 
 void ml::Timers::tick(void)

--- a/source/app/MLTimer.h
+++ b/source/app/MLTimer.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <chrono>
+#include <functional>
 #include <iostream>
 #include <mutex>
 #include <set>


### PR DESCRIPTION
Adds a basic implementation of `ml::Timers::stop` for ML_LINUX which is patterned off of the existing `start` and `run` implementations.