### PR TITLE
Add very basic CI using GitHub actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: 'test'
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: 'test'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'configure cmake'
+        run: cmake -B ./build
+      - name: 'build'
+        run: cmake --build ./build -- tests
+      - name: 'run tests'
+        run: ./build/bin/tests

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There are three examples built using RtAudio that play and process audio signals
 
 The code in /source/app is also relied upon by shipping products, though it may still change more often. 
 
-Tests exist for most modules. Someone should set up continuous integration.
+Tests exist for most modules. Very basic continuous integration exists using GitHub actions, but only tests on MacOS at present.
 
 OSC (Open Sound control) networking still awaits porting to Windows / Linux.
 


### PR DESCRIPTION
This adds a very simple github action that will run on pushes to `master`, and on any pull requests opened. It only tests on Mac for now, as the tests didn't seem to immediately pass on Windows, and there's some complexity that I haven't yet figured out about the `cmake --build` command with extra arguments on Windows. Will dig in to that a little later.

An example of a successful CI run can be seen here: https://github.com/goonzoid/madronalib/actions/runs/2673480803.