### PR TITLE
fix: Use std::isnan and std::isinf consistently

### DIFF
--- a/source/DSP/MLDSPScalarMath.h
+++ b/source/DSP/MLDSPScalarMath.h
@@ -129,13 +129,13 @@ inline int ilog2(int x)
   return b;
 }
 
-inline int isNaN(float x) { return isnan(x); }
+inline int isNaN(float x) { return std::isnan(x); }
 
-inline int isNaN(double x) { return isnan(x); }
+inline int isNaN(double x) { return std::isnan(x); }
 
-inline int isInfinite(float x) { return isinf(x); }
+inline int isInfinite(float x) { return std::isinf(x); }
 
-inline int isInfinite(double x) { return isinf(x); }
+inline int isInfinite(double x) { return std::isinf(x); }
 
 inline float smoothstep(float a, float b, float x)
 {

--- a/source/app/MLTextUtils.cpp
+++ b/source/app/MLTextUtils.cpp
@@ -5,6 +5,7 @@
 #include "MLTextUtils.h"
 
 #include <cstring>
+#include <cmath>
 
 #include "MLDSPScalarMath.h"
 #include "MLMemoryUtils.h"
@@ -194,7 +195,7 @@ TextFragment floatNumberToText(float f, int precision)
   float value = f;
   const int digitsAfterDecimal{std::min(precision, kMaxPrecision)};
 
-  if (isnan(f))
+  if (std::isnan(f))
   {
     *writePtr++ = 'n';
     *writePtr++ = 'a';


### PR DESCRIPTION
These changes allow compilation with gcc 10 on debian/buster.