### PR TITLE
Fix possible erroneous comparison against FLT_MIN

### DIFF
--- a/source/DSP/MLDSPOps.h
+++ b/source/DSP/MLDSPOps.h
@@ -1017,7 +1017,7 @@ inline float mean(const DSPVector& x)
 inline float max(const DSPVector& x)
 {
   const float* px1 = x.getConstBuffer();
-  float fmax = FLT_MIN;
+  float fmax = std::numeric_limits<float>::lowest();
   for (int n = 0; n < kSIMDVectorsPerDSPVector; ++n)
   {
     fmax = ml::max(fmax, vecMaxH(vecLoad(px1)));


### PR DESCRIPTION
Hi Randy,

I'm not going to pretend to understand this, but it appears that the comparison against `FLT_MIN` inside `ml::max` may spuriously have unexpected behavior in some corner cases. In my case, in a particular Blockhead project, a comparison would occur between `FLT_MIN` and the number `-2292474.0`, which would bizarrely return `FLT_MIN` as the maximum of the two. I have no idea what the precise conditions are for this to occur. Perhaps it is even a bug in Microsoft's compiler. I had a suspicion that instead comparing against `std::numeric_limits<float>::lowest()` might fix it, and it did!