### PR TITLE
Update Example Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ Madronalib can be built with the default settings as follows:
 	make
     
 This will create a command-line build of all the new code.
+
+To build and install with debug symbols enabled for use with the example plugin projects:
+
+	mkdir build
+	cd build
+	cmake -DCMAKE_BUILD_TYPE=Debug ..
+	make
+	# Installation may require administrator account / sudo
+	make install
+
 To build an XCode project with JUCE support, run something like
 
 	mkdir build-xcode

--- a/examples/effect-plugin/CMakeLists.txt
+++ b/examples/effect-plugin/CMakeLists.txt
@@ -26,7 +26,7 @@ project(llllPluginNamellll)
 set(VERSION_MAJOR "0")
 set(VERSION_MINOR "1")
 set(VERSION_PATCH "0")
-set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+set(PROJECT_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
  #--------------------------------------------------------------------
  # Compiler flags

--- a/examples/effect-plugin/CMakeLists.txt
+++ b/examples/effect-plugin/CMakeLists.txt
@@ -12,7 +12,7 @@ set(public_sdk_SOURCE_DIR ${VST3_SDK_ROOT}/public.sdk)
 
  IF(APPLE)
   SET(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architectures for Mac OS X" FORCE)
-  SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum OS X deployment version")
+  SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
  ENDIF(APPLE)
 
 #--------------------------------------------------------------------

--- a/examples/effect-plugin/CMakeLists.txt
+++ b/examples/effect-plugin/CMakeLists.txt
@@ -65,6 +65,7 @@ set(target llllpluginnamellll)
 
 SET(SMTG_ADD_VSTGUI OFF CACHE BOOL "Add VSTGUI support")
 SET(VSTGUI_TOOLS OFF CACHE BOOL "Build VSTGUI Tools")
+SET(SMTG_CREATE_MODULE_INFO OFF CACHE BOOL "Disable Module Info Generation")
 
 include(VST3_SDK.cmake)
 
@@ -78,7 +79,7 @@ if(SMTG_ADD_VSTGUI)
 endif()
 
 if(SMTG_MAC)
-    smtg_set_bundle(${target} INFOPLIST "${CMAKE_CURRENT_LIST_DIR}/mac/Info.plist" PREPROCESS)
+    smtg_target_set_bundle(${target} INFOPLIST "${CMAKE_CURRENT_LIST_DIR}/mac/Info.plist" PREPROCESS)
     target_link_libraries(${target} PRIVATE "-framework CoreAudio" )
 
 elseif(SMTG_WIN)

--- a/examples/effect-plugin/README.md
+++ b/examples/effect-plugin/README.md
@@ -7,7 +7,7 @@ Example of a VST3 / Audio Units plugin made with cmake, madronalib and the VST3 
 to build:
 ---------
 
-First, build and install madronalib as a static library using the instructions in the madronalib project.
+First, build and install madronalib as a **debug** static library using the instructions in the madronalib project.
 
 Download the VST3 SDK from Steinberg.
 

--- a/examples/effect-plugin/README.md
+++ b/examples/effect-plugin/README.md
@@ -19,7 +19,7 @@ To make the VST and AU plugins, first create an XCode project for MacOS using cm
 
 - mkdir build
 - cd build
-- cmake -DVST3_SDK_ROOT=(your VST3 SDK location) -DCMAKE_BUILD_TYPE=Debug -GXcode ..
+- cmake -DVST3_SDK_ROOT=(your VST3 SDK location) -DSMTG_RUN_VST_VALIDATOR=OFF -DCMAKE_BUILD_TYPE=Debug -GXcode ..
 
 Cmake will create a project with obvious placeholders (llllCompanyllll, llllPluginNamellll) for the company and plugin names. 
 

--- a/examples/effect-plugin/source/pluginController.cpp
+++ b/examples/effect-plugin/source/pluginController.cpp
@@ -63,7 +63,7 @@ void GainParameter::toString(ParamValue normValue, String128 string) const
 
 bool GainParameter::fromString(const TChar* string, ParamValue& normValue) const
 {
-  String wrapper((TChar*)string); // don't know buffer size here!
+  Steinberg::UString wrapper((TChar*)string, 128); // don't know buffer size here!
   double tmp = 0.0;
   if(wrapper.scanFloat(tmp))
   {

--- a/examples/effect-plugin/source/pluginProcessor.cpp
+++ b/examples/effect-plugin/source/pluginProcessor.cpp
@@ -164,10 +164,6 @@ tresult PLUGIN_API PluginProcessor::canProcessSampleSize(int32 symbolicSampleSiz
   if(symbolicSampleSize == kSample32)
     return kResultTrue;
   
-  // we support double processing
-  if(symbolicSampleSize == kSample64)
-    return kResultTrue;
-  
   return kResultFalse;
 }
 

--- a/examples/synth-plugin/CMakeLists.txt
+++ b/examples/synth-plugin/CMakeLists.txt
@@ -85,6 +85,7 @@ set(target llllpluginnamellll)
 
 SET(SMTG_ADD_VSTGUI OFF CACHE BOOL "Add VSTGUI support")
 SET(VSTGUI_TOOLS OFF CACHE BOOL "Build VSTGUI Tools")
+SET(SMTG_CREATE_MODULE_INFO OFF CACHE BOOL "Disable Module Info Generation")
 
 include(VST3_SDK.cmake)
 
@@ -98,7 +99,7 @@ if(SMTG_ADD_VSTGUI)
 endif()
 
 if(SMTG_MAC)
-    smtg_set_bundle(${target} INFOPLIST "${CMAKE_CURRENT_LIST_DIR}/mac/Info.plist" PREPROCESS)
+    smtg_target_set_bundle(${target} INFOPLIST "${CMAKE_CURRENT_LIST_DIR}/mac/Info.plist" PREPROCESS)
     target_link_libraries(${target} PRIVATE "-framework CoreAudio" )
 elseif(SMTG_WIN)
     target_sources(${target} PRIVATE resource/llllpluginnamellll.rc)

--- a/examples/synth-plugin/CMakeLists.txt
+++ b/examples/synth-plugin/CMakeLists.txt
@@ -11,7 +11,7 @@ set(public_sdk_SOURCE_DIR ${VST3_SDK_ROOT}/public.sdk)
 
  IF(APPLE)
   SET(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architectures for Mac OS X" FORCE)
-  SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum OS X deployment version")
+  SET(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
  ENDIF(APPLE)
 
 #--------------------------------------------------------------------

--- a/examples/synth-plugin/CMakeLists.txt
+++ b/examples/synth-plugin/CMakeLists.txt
@@ -25,7 +25,7 @@ project(llllPluginNamellll)
 set(VERSION_MAJOR "0")
 set(VERSION_MINOR "1")
 set(VERSION_PATCH "0")
-set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+set(PROJECT_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
  #--------------------------------------------------------------------
  # Compiler flags

--- a/examples/synth-plugin/README.md
+++ b/examples/synth-plugin/README.md
@@ -7,7 +7,7 @@ Example of a VST3 / Audio Units plugin made with cmake, madronalib and the VST3 
 to build:
 ---------
 
-First, build and install madronalib as a static library using the instructions in the madronalib project.
+First, build and install madronalib as a **debug** static library using the instructions in the madronalib project.
 
 Download the VST3 SDK from Steinberg.
 

--- a/examples/synth-plugin/README.md
+++ b/examples/synth-plugin/README.md
@@ -19,7 +19,7 @@ To make the VST and AU plugins, first create an XCode project for MacOS using cm
 
 - mkdir build
 - cd build
-- cmake -DVST3_SDK_ROOT=(your VST3 SDK location) -DCMAKE_BUILD_TYPE=Debug -GXcode ..
+- cmake -DVST3_SDK_ROOT=(your VST3 SDK location) -DSMTG_RUN_VST_VALIDATOR=OFF -DCMAKE_BUILD_TYPE=Debug -GXcode ..
 
 Cmake will create a project with obvious placeholders (llllCompanyllll, llllPluginNamellll) for the company and plugin names. 
 

--- a/examples/synth-plugin/source/pluginProcessor.cpp
+++ b/examples/synth-plugin/source/pluginProcessor.cpp
@@ -110,7 +110,7 @@ tresult PLUGIN_API PluginProcessor::setupProcessing(ProcessSetup& newSetup)
   _sampleRate = newSetup.sampleRate;
   
   // setup synth inputs
-  _synthInput = make_unique< EventsToSignals >(_sampleRate);
+  _synthInput = std::make_unique< EventsToSignals >(_sampleRate);
   _synthInput->setPolyphony(kMaxVoices);
   
   // setup glides

--- a/examples/synth-plugin/source/pluginProcessor.cpp
+++ b/examples/synth-plugin/source/pluginProcessor.cpp
@@ -148,10 +148,6 @@ tresult PLUGIN_API PluginProcessor::canProcessSampleSize(int32 symbolicSampleSiz
   if(symbolicSampleSize == kSample32)
     return kResultTrue;
   
-  // we support double processing
-  if(symbolicSampleSize == kSample64)
-    return kResultTrue;
-  
   return kResultFalse;
 }
 


### PR DESCRIPTION
Various bugfixes and updates for the example projects.

A few things of note:

b25b7ad - Perhaps there is a different way to set a default sample size. Since `madronalib` will not support 32-bit samples, it seemed correct to remove 64-bit sample processing from the plugin's advertised capabilities.

f601cf0 - This may be incorrect. I intuited the type `Steinberg::UString` from the member function `scanFloat` -- but I had to change the constructor to specify an explicit size. Per the comment, we don't know the correct buffer size at compile time.

6f784a3: 
- `-DSMTG_RUN_VST_VALIDATOR=OFF` - The VST SDK appears to perform validation testing by default now. There were some failures, but I did not want to hard-code this setting into the cmake file, and added it to the README instructions instead.
- `SMTG_CREATE_MODULE_INFO` - The VST SDK added a new optional tool `moduleinfotool`. It does not appear that we need it, so I disabled it in the CMake file