### PR TITLE
Fix VST Validator issue in synth-plugin example

### DIFF
--- a/examples/synth-plugin/source/pluginController.cpp
+++ b/examples/synth-plugin/source/pluginController.cpp
@@ -65,7 +65,8 @@ tresult PLUGIN_API PluginController::initialize(FUnknown* context)
     int newUnitID = kMIDIParamsUnitIDStart + chan;
     int newParamID{0};
     TextFragment unitNameText("channel", ml::textUtils::naturalNumberToText(chan + 1));
-    unitInfo.parentUnitId = newUnitID;
+    unitInfo.id = newUnitID;
+    unitInfo.parentUnitId = kRootUnitId;
     unitInfo.programListId = Steinberg::Vst::kNoProgramListId;
     unitNameSetter.fromAscii(unitNameText.getText());
     addUnit(new Steinberg::Vst::Unit(unitInfo));


### PR DESCRIPTION
The VST Validator had a few errors related to UnitInfo IDs. Updated example to use the previously calculated id + set the parent to the root unit.