### PR TITLE
Fix/main build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,12 @@ elseif(WIN32)
 else()
     # GCC/Clang on Linux
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g")
+
+    # Enable SSE4.1 on x86_64 so SSE4 intrinsics in MLDSPMathSSE.h compile.
+    # GCC's default x86_64 baseline is SSE2; _mm_mullo_epi32 needs SSE4.1.
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
+    endif()
 endif()
 
 #--------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ target_include_directories(${target} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/source/matrix>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/source/networking>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/oscpack>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/oscpack/ip>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/oscpack/osc>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/oscpack/zeroconf>

--- a/Tests/dspFiltersTest.cpp
+++ b/Tests/dspFiltersTest.cpp
@@ -575,7 +575,7 @@ TEST_CASE("madronalib/filters/pink_filter_rolloff", "[filters]")
 {
   constexpr int kFFTOrder = 6;
   ffft::FFTRealFixLen<kFFTOrder> fft;
-  constexpr int N = kFramesPerBlock;
+  static constexpr int N = kFramesPerBlock;
   
   auto measureRolloff = [&](float sr) {
     PinkFilter<float> pf;

--- a/source/DSP/MLDSPMath.h
+++ b/source/DSP/MLDSPMath.h
@@ -123,13 +123,13 @@ inline float reinterpretFloatAsInt(uint32_t f)
   return (*reinterpret_cast<float*>(&f));
 }
 
-inline float log(float x) { return std::logf(x); }
-inline float exp(float x) { return std::expf(x); }
-inline float sin(float x) { return std::sinf(x); }
-inline float cos(float x) { return std::cosf(x); }
+inline float log(float x) { return std::log(x); }
+inline float exp(float x) { return std::exp(x); }
+inline float sin(float x) { return std::sin(x); }
+inline float cos(float x) { return std::cos(x); }
 inline std::pair<float, float> sincos(float x) { return{sin(x), cos(x)};
 }
-inline float  tan(float  x) { return std::tanf(x); }
+inline float  tan(float  x) { return std::tan(x); }
 inline float4 tan(float4 x) { return sin(x) / cos(x); }
 
 // other utilities

--- a/source/DSP/MLDSPOps.h
+++ b/source/DSP/MLDSPOps.h
@@ -24,6 +24,7 @@
 
 #include <array>
 #include <iostream>
+#include <vector>
 
 #include "MLDSPMath.h"
 #include "MLDSPMathApprox.h"

--- a/source/app/MLAudioDevice.cpp
+++ b/source/app/MLAudioDevice.cpp
@@ -126,7 +126,7 @@ unsigned int AudioDevice::startAudio(const AudioProcessData& processData)
 
 void AudioDevice::stopAudio()
 {
-  if (!pImpl->deviceController_) return 0;
+  if (!pImpl->deviceController_) return;
   RtAudio& ctrl = *pImpl->deviceController_;
 
   if (RTAUDIO_NO_ERROR != ctrl.stopStream())
@@ -135,6 +135,12 @@ void AudioDevice::stopAudio()
   }
   
   if (ctrl.isStreamOpen()) ctrl.closeStream();
+}
+
+long AudioDevice::getStreamLatency()
+{
+  if (!pImpl->deviceController_) return 0;
+  return pImpl->deviceController_->getStreamLatency();
 }
 
 int AudioDevice::getOutputSampleRate()

--- a/source/app/MLAudioDevice.h
+++ b/source/app/MLAudioDevice.h
@@ -29,7 +29,8 @@ public:
   ~AudioDevice();
 
   int getOutputSampleRate();
-  
+  long getStreamLatency();
+
   unsigned int startAudio(const AudioProcessData& processData);
   void stopAudio();
   


### PR DESCRIPTION
## Summary

Fixes the build of `main` on macOS, Windows, and Linux. The library has been failing to compile cleanly on `main` for a while; this PR collects the minimal set of changes that get all three platforms past the build step, and gets macOS and Windows fully green in CI.

The diff is small (six files, relatively tightly scoped) but the failures span several categories — see the per-fix breakdown below.

## What's fixed

| # | Commit | Issue |
|---|--------|-------|
| 1 | Fix `stopAudio` return-value typo and restore `AudioDevice::getStreamLatency` accessor | `stopAudio()` is `void` but returned `0`; the latency accessor on `AudioDevice` was lost during the recent `_adac` → `devs` refactor (`579e1065`). |
| 2 | Use `std::log/exp/sin/cos/tan` instead of `std::*f` forms | `std::sinf` etc. are not required to exist by the C++ standard — they live in `<math.h>` in the global namespace. libc++ (macOS) provides them as an extension; libstdc++ (Linux) does not.  |
| 3 | Add oscpack root to include path for Windows `ip/...` includes | The `ip/win32/{NetworkingUtils,UdpSocket}.cpp` files `#include "ip/NetworkingUtils.h"` relative to the oscpack root, but only `external/oscpack/ip` was on the include path. macOS/Linux build the `posix/` siblings instead and don't trip on this. |
| 4 | Add missing `<vector>` include to `MLDSPOps.h` | `SignalBlockDynamic` uses `std::vector` but `MLDSPOps.h` only included `<array>` and `<iostream>`. Picked up transitively by libc++; not by libstdc++ or MSVC. |
| 5 | Enable SSE4.1 on Linux x86_64 for SSE4 intrinsics in `MLDSPMathSSE.h` | `_mm_mullo_epi32` (used in `multiplyUnsigned`) is SSE4.1. GCC's default x86_64 baseline is SSE2; Apple Clang and MSVC both default to enabling SSE4.1. Only triggered from test code, so the library builds without it; the test target requires it. |
| 6 | Make `N` `static constexpr` in `pink_filter_rolloff` test | MSVC treats a non-static `constexpr` local as captured-by-reference in `[&]` lambdas and rejects it as a non-constant expression in `std::array<float, N>`. Promoting to `static constexpr` puts it in static storage so capture isn't required. |

## CI status after this PR

| Platform | Build | Test |
|----------|-------|------|
| macOS    | ✅    | ✅ |
| Windows  | ✅    | ✅ |
| Linux    | ✅    | ⚠️ |

## Known follow-up: latent SSE correctness bug on Linux

After this PR, the Linux job builds cleanly and reaches `Run tests`. **3 of 114 test cases (10 of 3736 assertions) fail** with patterns that suggest a pre-existing SIMD loop-bound bug in `MLDSPOps.h`:
```
dspOpsTest.cpp:295  sum(rangeClosed(0..63))            got -2,642,439,569,408   expected 2016
dspOpsTest.cpp:314  map(square, rangeClosed(0..1))[63] got 0                    expected 1
dspOpsTest.cpp:440  addRows                            wrong sum
eventsToSignalsTest.cpp:155  pitchAt(0, kFramesPerBlock-1)  got 115             expected 60
eventsToSignalsTest.cpp:211  foundPitch60                   false
```
Index-0 assertions in the same tests pass; only "last element" (`kFramesPerBlock - 1`) and aggregate assertions fail — consistent with only the first SIMD lane being processed correctly, with the rest reading uninitialized memory.

This bug has been latent on `main` for some time. CI exercises NEON via the macOS Apple Silicon runner, but the SSE code path was never run:
- macOS CI builds a universal binary and runs it on `macos-15`, so the loader picks the arm64/NEON slice. The x86_64 slice is built but never executed.
- The Linux runner is x86_64 (would have caught this), but `-msse4.1` (fix #5) was missing, so the SSE path didn't compile and tests never ran far enough to expose it.

**Out of scope for this PR.** Filing as a separate issue. This PR's job is to get the build chain healthy on all three platforms; the runtime correctness bug needs some real DSP debugging.

## Test plan
- [x] macOS Debug + Release: clean build, 114/114 tests pass, 3755/3755 assertions
- [x] Windows: CI build + tests green
- [x] Linux: CI build green; `Run tests` step reaches the test binary (test failures documented above)
- [x] Verified each fix individually addresses the matching error in CI logs
