### PR TITLE
Ci/rebuild scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,9 +327,9 @@ endif()
 install(
     TARGETS ${target}
     EXPORT madronalib-targets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT library
 )
 
 # Install CMake package config files
@@ -369,8 +369,8 @@ message("madronalib destination: " ${CMAKE_INSTALL_LIBDIR} )
 
 # HEADERS_INCLUDE_DIR is defined earlier (used here and by target_include_directories)
 
-install(FILES include/madronalib.h DESTINATION ${HEADERS_INCLUDE_DIR})
-install(FILES include/mldsp.h DESTINATION ${HEADERS_INCLUDE_DIR})
+install(FILES include/madronalib.h DESTINATION ${HEADERS_INCLUDE_DIR} COMPONENT library)
+install(FILES include/mldsp.h DESTINATION ${HEADERS_INCLUDE_DIR} COMPONENT library)
 
 # TODO: don't install this, wrap
 # Install cJSON header (fetched via FetchContent, consumers get it from here)
@@ -384,6 +384,7 @@ install(FILES
     DESTINATION
     # PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
     ${HEADERS_INCLUDE_DIR}
+    COMPONENT library
   )
 
 # OSC headers are installed as part of APP_HEADERS (now in source/app/)

--- a/rebuild
+++ b/rebuild
@@ -5,7 +5,9 @@ MADRONALIB_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Configure if needed
 if [ ! -d "$MADRONALIB_ROOT/build/madronalib.xcodeproj" ]; then
-    cmake -S "$MADRONALIB_ROOT" -B "$MADRONALIB_ROOT/build" -GXcode
+    cmake -S "$MADRONALIB_ROOT" -B "$MADRONALIB_ROOT/build" -GXcode \
+        -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="10.14"
 fi
 
 # Clean installed files
@@ -17,10 +19,10 @@ sudo rm -rf /usr/local/lib/cmake/madronalib
 # Build and install Debug
 cd "$MADRONALIB_ROOT/build"
 xcodebuild build -configuration Debug -target madronalib
-sudo cmake -DBUILD_TYPE=Debug -DCOMPONENT=library -P cmake_install.cmake
+sudo cmake -DBUILD_TYPE=Debug -P cmake_install.cmake
 
 # Build and install Release
 xcodebuild build -configuration Release -target madronalib
-sudo cmake -DBUILD_TYPE=Release -DCOMPONENT=library -P cmake_install.cmake
+sudo cmake -DBUILD_TYPE=Release -P cmake_install.cmake
 
 echo "Done."

--- a/rebuild
+++ b/rebuild
@@ -19,10 +19,10 @@ sudo rm -rf /usr/local/lib/cmake/madronalib
 # Build and install Debug
 cd "$MADRONALIB_ROOT/build"
 xcodebuild build -configuration Debug -target madronalib
-sudo cmake -DBUILD_TYPE=Debug -P cmake_install.cmake
+sudo cmake -DBUILD_TYPE=Debug -DCOMPONENT=library -P cmake_install.cmake
 
 # Build and install Release
 xcodebuild build -configuration Release -target madronalib
-sudo cmake -DBUILD_TYPE=Release -P cmake_install.cmake
+sudo cmake -DBUILD_TYPE=Release -DCOMPONENT=library -P cmake_install.cmake
 
 echo "Done."

--- a/rebuild
+++ b/rebuild
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+MADRONALIB_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Configure if needed
+if [ ! -d "$MADRONALIB_ROOT/build/madronalib.xcodeproj" ]; then
+    cmake -S "$MADRONALIB_ROOT" -B "$MADRONALIB_ROOT/build" -GXcode
+fi
+
+# Clean installed files
+sudo rm -rf /usr/local/include/madronalib
+sudo rm -f /usr/local/lib/libmadrona-debug.a
+sudo rm -f /usr/local/lib/libmadrona.a
+sudo rm -rf /usr/local/lib/cmake/madronalib
+
+# Build and install Debug
+cd "$MADRONALIB_ROOT/build"
+xcodebuild build -configuration Debug -target madronalib
+sudo cmake -DBUILD_TYPE=Debug -DCOMPONENT=library -P cmake_install.cmake
+
+# Build and install Release
+xcodebuild build -configuration Release -target madronalib
+sudo cmake -DBUILD_TYPE=Release -DCOMPONENT=library -P cmake_install.cmake
+
+echo "Done."

--- a/rebuild-ninja
+++ b/rebuild-ninja
@@ -8,7 +8,9 @@ BUILD_DIR="$MADRONALIB_ROOT/build-ninja"
 if [ ! -f "$BUILD_DIR/build.ninja" ]; then
     cmake -S "$MADRONALIB_ROOT" -B "$BUILD_DIR" \
         -G "Ninja Multi-Config" \
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="10.14"
 fi
 
 # Clean installed files

--- a/rebuild-ninja
+++ b/rebuild-ninja
@@ -21,10 +21,10 @@ sudo rm -rf /usr/local/lib/cmake/madronalib
 
 # Build and install Debug
 cmake --build "$BUILD_DIR" --config Debug --target madronalib
-sudo cmake --install "$BUILD_DIR" --config Debug
+sudo cmake --install "$BUILD_DIR" --config Debug --component library
 
 # Build and install Release
 cmake --build "$BUILD_DIR" --config Release --target madronalib
-sudo cmake --install "$BUILD_DIR" --config Release
+sudo cmake --install "$BUILD_DIR" --config Release --component library
 
 echo "Done."


### PR DESCRIPTION
- add universal build for macOS to rebuild scripts
- create `rebuild` for parity with manzanita which has `rebuild` and `rebuild-ninja`
- also tag install with COMPONENT for parity with manzanita