### PR TITLE
tests: Add Catch coverage for Synth and Effect base classes

### DIFF
--- a/Tests/effectTest.cpp
+++ b/Tests/effectTest.cpp
@@ -1,0 +1,99 @@
+// madronalib: a C++ framework for DSP applications.
+// Copyright (c) 2026 Madrona Labs LLC. http://www.madronalabs.com
+// Distributed under the MIT license: http://madrona-labs.mit-license.org/
+
+// Compile-time and minimal runtime coverage for the Effect base class
+// in source/app/MLEffect.h. Like synthTest.cpp, the primary goal is to
+// instantiate an Effect subclass inside madronalib so processVector's
+// override signature is exercised by the in-repo build.
+
+#include "catch.hpp"
+#include "MLEffect.h"
+#include "MLAudioContext.h"
+#include "MLDSPOps.h"
+
+using namespace ml;
+
+namespace {
+
+// Trivial Effect subclass that doubles every sample. Records whether
+// processVector was actually called so the test can detect a silently
+// missed override.
+class TestEffect : public Effect {
+public:
+  void processVector(const SignalBlockDynamic& inputs,
+                     SignalBlockDynamic& outputs,
+                     AudioContext* audioContext) override {
+    processCallCount++;
+    lastContext = audioContext;
+
+    int channels = std::min(inputs.size(), outputs.size());
+    for (int i = 0; i < channels; ++i) {
+      outputs[i] = inputs[i] * SignalBlock{2.0f};
+    }
+  }
+
+  int processCallCount{0};
+  AudioContext* lastContext{nullptr};
+};
+
+}  // namespace
+
+TEST_CASE("Effect base class default processVector is multichannel passthrough",
+          "[effect]") {
+  Effect effect;
+
+  SignalBlockDynamic inputs(2);
+  SignalBlockDynamic outputs(2);
+  inputs[0] = SignalBlock{0.25f};
+  inputs[1] = SignalBlock{-0.75f};
+  outputs[0] = SignalBlock{99.f};
+  outputs[1] = SignalBlock{99.f};
+
+  effect.processVector(inputs, outputs, nullptr);
+
+  for (size_t i = 0; i < kFramesPerBlock; ++i) {
+    REQUIRE(outputs[0][i] == Approx(0.25f));
+    REQUIRE(outputs[1][i] == Approx(-0.75f));
+  }
+}
+
+TEST_CASE("Effect base class zeroes extra output channels", "[effect]") {
+  Effect effect;
+
+  SignalBlockDynamic inputs(1);
+  SignalBlockDynamic outputs(2);
+  inputs[0] = SignalBlock{0.5f};
+  outputs[0] = SignalBlock{99.f};
+  outputs[1] = SignalBlock{99.f};
+
+  effect.processVector(inputs, outputs, nullptr);
+
+  for (size_t i = 0; i < kFramesPerBlock; ++i) {
+    REQUIRE(outputs[0][i] == Approx(0.5f));
+    REQUIRE(outputs[1][i] == Approx(0.0f));
+  }
+}
+
+TEST_CASE("Effect subclass processVector override runs with AudioContext",
+          "[effect]") {
+  TestEffect effect;
+  effect.setSampleRate(48000.0);
+
+  AudioContext ctx(2, 2);
+  ctx.setSampleRate(48000);
+
+  SignalBlockDynamic inputs(2);
+  SignalBlockDynamic outputs(2);
+  inputs[0] = SignalBlock{0.5f};
+  inputs[1] = SignalBlock{-0.5f};
+
+  effect.processVector(inputs, outputs, &ctx);
+
+  REQUIRE(effect.processCallCount == 1);
+  REQUIRE(effect.lastContext == &ctx);
+  for (size_t i = 0; i < kFramesPerBlock; ++i) {
+    REQUIRE(outputs[0][i] == Approx(1.0f));
+    REQUIRE(outputs[1][i] == Approx(-1.0f));
+  }
+}

--- a/Tests/synthTest.cpp
+++ b/Tests/synthTest.cpp
@@ -1,0 +1,118 @@
+// madronalib: a C++ framework for DSP applications.
+// Copyright (c) 2026 Madrona Labs LLC. http://www.madronalabs.com
+// Distributed under the MIT license: http://madrona-labs.mit-license.org/
+
+// Compile-time and minimal runtime coverage for the Synth base class in
+// source/app/MLSynth.h. The point of this test is to instantiate a Synth
+// subclass inside madronalib so that the processVoice/processVector
+// override signatures get type-checked by the in-repo build — without
+// this, drift in those signatures only surfaces in downstream consumers
+// (Aalto, Aaltoverb).
+
+#include "catch.hpp"
+#include "MLSynth.h"
+#include "MLAudioContext.h"
+#include "MLDSPOps.h"
+#include "MLEvent.h"
+
+using namespace ml;
+
+namespace {
+
+// Trivial Synth subclass: writes the voice's gate signal into output 0
+// and tracks how many times processVoice has been called. We do not
+// care about audio fidelity — only that the override chain compiles
+// against the current base-class signature and that processVector
+// actually dispatches into processVoice.
+class TestSynth : public Synth {
+public:
+  explicit TestSynth(int numVoices = 2) : Synth(numVoices) {}
+
+  void processVoice(int voiceIndex,
+                    const EventsToSignals::Voice& voice,
+                    const SignalBlockDynamic& inputs,
+                    SignalBlockDynamic& outputs,
+                    AudioContext* audioContext) override {
+    voiceCallCount++;
+    lastVoiceIndex = voiceIndex;
+    lastSampleRate = audioContext ? audioContext->getSampleRate() : 0.0;
+
+    // Accumulate a constant into output 0 so the test can confirm we ran.
+    if (outputs.size() > 0) {
+      SignalBlock contribution{1.0f};
+      outputs[0] += contribution;
+    }
+  }
+
+  int voiceCallCount{0};
+  int lastVoiceIndex{-1};
+  double lastSampleRate{0.0};
+};
+
+}  // namespace
+
+TEST_CASE("Synth base class processVector dispatches to processVoice", "[synth]") {
+  constexpr int kNumVoices = 2;
+  TestSynth synth(kNumVoices);
+  synth.setSampleRate(44100.0);
+
+  AudioContext ctx(0, 1);
+  ctx.setSampleRate(44100);
+  ctx.setInputPolyphony(kNumVoices);
+
+  SignalBlockDynamic inputs(0);
+  SignalBlockDynamic outputs(1);
+  outputs[0] = SignalBlock{0.f};
+
+  synth.processVector(inputs, outputs, &ctx);
+
+  // isVoiceActive() returns true by default, so every voice should run.
+  REQUIRE(synth.voiceCallCount == kNumVoices);
+  REQUIRE(synth.getActiveVoiceCount() == kNumVoices);
+  REQUIRE(synth.lastSampleRate == Approx(44100.0));
+
+  // Each voice added 1.0 to outputs[0], so every sample should equal kNumVoices.
+  for (size_t i = 0; i < kFramesPerBlock; ++i) {
+    REQUIRE(outputs[0][i] == Approx(static_cast<float>(kNumVoices)));
+  }
+}
+
+// TODO: no-op on null AudioContext might be a bad pattern. I don't remember if this is done elsewhere
+TEST_CASE("Synth processVector with null AudioContext is a no-op", "[synth]") {
+  TestSynth synth(2);
+  SignalBlockDynamic inputs(0);
+  SignalBlockDynamic outputs(1);
+  outputs[0] = SignalBlock{0.5f};
+
+  synth.processVector(inputs, outputs, nullptr);
+
+  REQUIRE(synth.voiceCallCount == 0);
+  // outputs untouched
+  REQUIRE(outputs[0][0] == Approx(0.5f));
+}
+
+TEST_CASE("Synth honors isVoiceActive override", "[synth]") {
+  class GatedSynth : public TestSynth {
+  public:
+    using TestSynth::TestSynth;
+    bool isVoiceActive(int voiceIndex,
+                       const EventsToSignals::Voice&) override {
+      return voiceIndex == 0;
+    }
+  };
+
+  GatedSynth synth(4);
+  AudioContext ctx(0, 1);
+  ctx.setSampleRate(44100);
+  ctx.setInputPolyphony(4);
+
+  SignalBlockDynamic inputs(0);
+  SignalBlockDynamic outputs(1);
+  outputs[0] = SignalBlock{0.f};
+
+  synth.processVector(inputs, outputs, &ctx);
+
+  REQUIRE(synth.voiceCallCount == 1);
+  REQUIRE(synth.getActiveVoiceCount() == 1);
+  REQUIRE(synth.hasActiveVoices());
+}


### PR DESCRIPTION
heads up to future-me and @randyjonesworld :

Apparently `Synth::processVector` is currently a no-op if the `AudioContext` is `nullptr`. Could be a bad design and bite us in cases like:
```
mySynth.processVector(ins, outs);
mySynth.processVector(ins, outs, ctx.get());       // if ctx is a stale unique_ptr, could be a nullptr? maybe??
```

see line 39 of `MLSynth.h`:
https://github.com/madrona-labs/madronalib/blob/9e19f9159fed497bf5f71c3563838c2cf45bc654/source/app/MLSynth.h#L35-L42